### PR TITLE
✨ 마이페이지 회원 정보 수정 페이지 구현

### DIFF
--- a/FinMate/src/components/info/UserInfoForm.vue
+++ b/FinMate/src/components/info/UserInfoForm.vue
@@ -8,18 +8,23 @@ const birthdate = ref("");
 
 const isDirty = computed(() => {
   return (
-    password.value !== "" ||
-    passwordCheck.value !== "" ||
+    (password.value !== "" &&
+      passwordCheck.value !== "" &&
+      isPasswordMatch.value) ||
     email.value !== "" ||
     birthdate.value !== ""
   );
+});
+
+const isPasswordMatch = computed(() => {
+  return passwordCheck.value === "" || password.value === passwordCheck.value;
 });
 </script>
 
 <template>
   <form class="user-info-form">
     <div class="form-group">
-      <label>아이디</label>
+      <label class="readonly-label">아이디</label>
       <input type="text" value="abc1234" disabled class="readonly-input" />
     </div>
 
@@ -39,6 +44,9 @@ const isDirty = computed(() => {
         placeholder="비밀번호를 한 번 더 입력해주세요"
         v-model="passwordCheck"
       />
+      <p v-if="passwordCheck && !isPasswordMatch" class="error-msg">
+        비밀번호가 일치하지 않습니다.
+      </p>
     </div>
 
     <div class="form-group">
@@ -83,6 +91,10 @@ const isDirty = computed(() => {
 
 .form-group label {
   margin-bottom: 0.5rem;
+}
+
+.readonly-label {
+  color: var(--color-light-gray);
 }
 
 input,
@@ -166,5 +178,14 @@ input:focus,
 .submit.inactive {
   background-color: #cfcfcf;
   cursor: not-allowed;
+}
+
+.error-msg {
+  color: var(--color-red);
+  font-size: 0.75rem;
+  margin-top: 0.3rem;
+  margin-left: 0.2rem;
+  font-family: "Inter", sans-serif;
+  font-weight: bold;
 }
 </style>

--- a/FinMate/src/components/info/UserInfoForm.vue
+++ b/FinMate/src/components/info/UserInfoForm.vue
@@ -1,0 +1,170 @@
+<script setup>
+import { ref, computed } from "vue";
+
+const password = ref("");
+const passwordCheck = ref("");
+const email = ref("");
+const birthdate = ref("");
+
+const isDirty = computed(() => {
+  return (
+    password.value !== "" ||
+    passwordCheck.value !== "" ||
+    email.value !== "" ||
+    birthdate.value !== ""
+  );
+});
+</script>
+
+<template>
+  <form class="user-info-form">
+    <div class="form-group">
+      <label>아이디</label>
+      <input type="text" value="abc1234" disabled class="readonly-input" />
+    </div>
+
+    <div class="form-group">
+      <label>비밀번호</label>
+      <input
+        type="password"
+        placeholder="새 비밀번호를 입력해주세요"
+        v-model="password"
+      />
+    </div>
+
+    <div class="form-group">
+      <label>비밀번호 확인*</label>
+      <input
+        type="password"
+        placeholder="비밀번호를 한 번 더 입력해주세요"
+        v-model="passwordCheck"
+      />
+    </div>
+
+    <div class="form-group">
+      <label>이메일</label>
+      <div class="email-group">
+        <input type="email" v-model="email" />
+        <button type="button" class="verify-btn">인증</button>
+      </div>
+    </div>
+
+    <div class="form-group">
+      <label>생년월일</label>
+      <input type="text" placeholder="yyyymmdd" v-model="birthdate" />
+    </div>
+
+    <div class="btn-group">
+      <button
+        type="submit"
+        class="submit"
+        :class="{ inactive: !isDirty }"
+        :disabled="!isDirty"
+      >
+        변경사항 저장
+      </button>
+    </div>
+  </form>
+</template>
+
+<style scoped>
+.user-info-form {
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+  font-family: var(--font-tmon);
+}
+
+.form-group {
+  display: flex;
+  flex-direction: column;
+  width: 70%;
+}
+
+.form-group label {
+  margin-bottom: 0.5rem;
+}
+
+input,
+.email-group input {
+  height: 3.3rem;
+  padding: 0 1rem 0 1.2rem;
+  border: 2px solid var(--color-black);
+  border-radius: 20px;
+  font-family: var(--font-tmon);
+  font-size: 0.8rem;
+  color: var(--color-black);
+  width: 100%;
+}
+
+input::placeholder,
+.email-group input::placeholder {
+  color: var(--color-light-gray);
+}
+
+input:focus,
+.email-group input:focus {
+  outline: none;
+  border-color: var(--color-orange);
+}
+
+.readonly-input {
+  font-size: 1.1rem;
+  color: var(--color-light-gray);
+}
+
+.email-group {
+  position: relative;
+  width: 100%;
+  margin-top: 0;
+}
+
+.email-group input {
+  padding-right: 6rem;
+}
+
+.verify-btn {
+  position: absolute;
+  top: 0;
+  right: 0;
+  height: 100%;
+  padding: 0 1.2rem;
+  background-color: var(--color-primary-yellow);
+  border: 2px solid black;
+  border-left: 2px solid black;
+  border-top-left-radius: 0;
+  border-bottom-left-radius: 0;
+  border-top-right-radius: 20px;
+  border-bottom-right-radius: 20px;
+  font-family: "Inter", sans-serif;
+  font-weight: bold;
+  cursor: pointer;
+}
+
+.btn-group {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.5rem;
+  margin-top: auto;
+}
+
+.submit {
+  background-color: var(--color-primary-green);
+  border: none;
+  padding: 0.8rem 2.5rem;
+  border-radius: 10px;
+  cursor: pointer;
+
+  box-shadow: 0 4px 6px rgba(0, 0, 0, 0.2);
+  transition: box-shadow 0.2s ease;
+}
+
+.submit:hover {
+  box-shadow: 0 6px 10px rgba(0, 0, 0, 0.25);
+}
+
+.submit.inactive {
+  background-color: #cfcfcf;
+  cursor: not-allowed;
+}
+</style>

--- a/FinMate/src/components/info/UserInfoForm.vue
+++ b/FinMate/src/components/info/UserInfoForm.vue
@@ -5,6 +5,35 @@ const password = ref("");
 const passwordCheck = ref("");
 const email = ref("");
 const birthdate = ref("");
+const isComposing = ref(false);
+
+const onCompositionStart = () => {
+  isComposing.value = true;
+};
+
+const onCompositionEnd = (e) => {
+  isComposing.value = false;
+  const raw = e.target.value;
+  const filtered = raw.replace(/[^0-9]/g, "");
+  birthdate.value = filtered;
+  e.target.value = filtered;
+};
+
+const onBirthdateInput = (e) => {
+  if (isComposing.value) return;
+  const raw = e.target.value;
+  const filtered = raw.replace(/[^0-9]/g, "");
+  birthdate.value = filtered;
+  e.target.value = filtered;
+};
+
+const isPasswordMatch = computed(() => {
+  return passwordCheck.value === "" || password.value === passwordCheck.value;
+});
+
+const isBirthdateValid = computed(() => {
+  return birthdate.value === "" || /^\d{8}$/.test(birthdate.value);
+});
 
 const isDirty = computed(() => {
   return (
@@ -14,10 +43,6 @@ const isDirty = computed(() => {
     email.value !== "" ||
     birthdate.value !== ""
   );
-});
-
-const isPasswordMatch = computed(() => {
-  return passwordCheck.value === "" || password.value === passwordCheck.value;
 });
 </script>
 
@@ -59,7 +84,19 @@ const isPasswordMatch = computed(() => {
 
     <div class="form-group">
       <label>생년월일</label>
-      <input type="text" placeholder="yyyymmdd" v-model="birthdate" />
+      <input
+        type="text"
+        placeholder="yyyymmdd"
+        :value="birthdate"
+        maxlength="8"
+        inputmode="numeric"
+        @input="onBirthdateInput"
+        @compositionstart="onCompositionStart"
+        @compositionend="onCompositionEnd"
+      />
+      <p v-if="!isBirthdateValid" class="error-msg">
+        생년월일은 yyyymmdd 형식으로 8자리 입력해주세요.
+      </p>
     </div>
 
     <div class="btn-group">

--- a/FinMate/src/styles/colors.css
+++ b/FinMate/src/styles/colors.css
@@ -15,6 +15,7 @@
   --color-main-button: #eaddbb;
   --color-dark-gray: #636362;
   --color-light-blue: #a4c8e1;
+  --color-light-gray: #c9c9c9;
 
   /* 설문 결과용 색상 */
   --color-survey-blue: #002bff;

--- a/FinMate/src/views/info/MyInfoView.vue
+++ b/FinMate/src/views/info/MyInfoView.vue
@@ -2,6 +2,7 @@
 import Sidebar from "@/components/info/Sidebar.vue";
 import TopNavigationBar from "@/components/allshared/TopNavigationBar.vue";
 import RightPanel from "@/components/info/RightPanel.vue";
+import UserInfoForm from "@/components/info/UserInfoForm.vue";
 </script>
 
 <template>
@@ -9,8 +10,10 @@ import RightPanel from "@/components/info/RightPanel.vue";
   <div class="mypage-container">
     <Sidebar />
     <RightPanel>
-      <h2>회원 정보 수정</h2>
-      <!-- TODO: UserInfoForm 추가 -->
+      <div class="panel-inner">
+        <h2 class="title">회원 정보 수정</h2>
+        <UserInfoForm />
+      </div>
     </RightPanel>
   </div>
 </template>
@@ -21,5 +24,15 @@ import RightPanel from "@/components/info/RightPanel.vue";
   gap: 2rem;
   padding: 2rem 4rem;
   align-items: flex-start;
+}
+
+.panel-inner {
+  display: flex;
+  flex-direction: column;
+}
+
+.title {
+  text-align: center;
+  margin-bottom: 1.5rem;
 }
 </style>


### PR DESCRIPTION
## 🔗 반영 브랜치
- closed #12
- `feature/my-page-info-edit → develop` 

## 📝 작업 내용
- 마이페이지 내 회원 정보 수정 폼 전체 구성
- 입력 필드: 아이디(읽기 전용), 비밀번호, 이메일, 생년월일
- 저장 버튼은 변경사항이 있을 경우에만 활성화
<img width="1707" height="973" alt="스크린샷 2025-07-22 오전 11 27 24" src="https://github.com/user-attachments/assets/43d1a586-b6d2-402d-8c66-cd8125366de9" />
<hr>

- 버튼 클릭 시 테두리 색상 변경
<img width="850" height="119" alt="스크린샷 2025-07-22 오전 11 27 34" src="https://github.com/user-attachments/assets/1579beec-e17f-4580-b7d5-345919e98ade" />
<hr>

- 비밀번호와 비밀번호 확인이 일치하지 않으면 에러 문구 표시
- 생년월일 입력 시 숫자만 허용하며, yyyymmdd 형식 미일치 시 에러 메시지 출력
- 유효하지 않은 입력일 경우 저장 버튼 비활성화 처리
<img width="854" height="259" alt="스크린샷 2025-07-22 오전 11 27 47" src="https://github.com/user-attachments/assets/fcaf911e-9989-4cf5-b551-c4d84edd9a75" />

## 💬 리뷰 요구사항(선택 사항)
.
