### PR TITLE
✨ 메인페이지 포트폴리오 및 스탯 부분 상태에 따른 UI 구현

### DIFF
--- a/FinMate/src/api/auth/auth.js
+++ b/FinMate/src/api/auth/auth.js
@@ -2,7 +2,7 @@ import axios from 'axios';
 
 export const Login = async (id, pw) => {
   try {
-    const response = await axios.post(`${API_BASE_URL}/auth/login`, {
+    const response = await axios.post(`${BASE_URL}/auth/login`, {
       username: id,
       password: pw,
     });

--- a/FinMate/src/api/main/main.js
+++ b/FinMate/src/api/main/main.js
@@ -1,0 +1,24 @@
+import axios from 'axios';
+
+const BASE_API_URL = import.meta.env.VITE_BASE_API_URL;
+
+export const getPortfolio = async () => {
+  try {
+    const token = localStorage.getItem('token');
+    const response = await axios.get(`${BASE_API_URL}/api/member/portfolio`, {
+      headers: {
+        Authorization: `Bearer ${token}`,
+        'Content-Type': 'application/json',
+      },
+    });
+    return response.data;
+  } catch (error) {
+    console.error('❌ Portfolio 요청 실패:', error);
+    if (error.response) {
+      console.error('❗ 서버 응답 데이터:', error.response.data);
+      console.error('❗ 서버 응답 상태코드:', error.response.status);
+      console.error('❗ 서버 응답 헤더:', error.response.headers);
+    }
+    throw error;
+  }
+};

--- a/FinMate/src/api/quiz/quiz.js
+++ b/FinMate/src/api/quiz/quiz.js
@@ -13,7 +13,7 @@ export const postAssessment = async (choices) => {
     console.log('[postAssessment] 사용자의 토큰:', token);
 
     const response = await axios.post(
-      `${BASE_API_URL}/assessment`,
+      `${BASE_API_URL}/api/assessment`,
       { choices },
       {
         headers: {

--- a/FinMate/src/components/main/ProfileContainer.vue
+++ b/FinMate/src/components/main/ProfileContainer.vue
@@ -50,7 +50,7 @@
   <DailyQuizModal v-if="showQuizModal" @close="showQuizModal = false" />
   <ConfirmModal
     v-if="showLogoutConfirm"
-    :text="'오늘의 금융 탐험은 여기까지!\n동물 친구들이 다음 추천을 준비 중이에요'"
+    :firsttext="'오늘의 금융 탐험은 여기까지!\n동물 친구들이 다음 추천을 준비 중이에요'"
     leftButtonText="취소"
     rightButtonText="로그아웃"
     @confirm="handleLogoutConfirm"

--- a/FinMate/src/components/main/ShowStatsContainer.vue
+++ b/FinMate/src/components/main/ShowStatsContainer.vue
@@ -1,7 +1,7 @@
 <template>
   <!-- 로그인 상태일 때: 통계 그래프 -->
-  <div v-if="isLoggedIn" class="show-stats-container">
-    <div class="stat-row" v-for="(stat, index) in statsLeft" :key="index">
+  <div v-if="isLoggedIn" class="show-stats-container-notlogin">
+    <!-- <div class="stat-row" v-for="(stat, index) in statsLeft" :key="index">
       <span class="stat-label">{{ stat.label }}</span>
       <div class="stat-bar-outer">
         <div
@@ -19,7 +19,28 @@
         ></div>
       </div>
     </div>
-    <button class="detail-button" @click="goToStatsPage">자세히 보기</button>
+    <button class="detail-button" @click="goToStatsPage">자세히 보기</button> -->
+    <div v-if="isstats" class="stats"></div>
+    <div v-if="!isstats" class="no-stats">
+      <div class="no-login-content">
+        <p class="nologin-text">
+          추천 아이템을 받으려면 <br />
+          투자 성향 테스트를 진행해주세요!
+        </p>
+        <button class="detail-button" @click="goToTest">테스트 시작하기</button>
+      </div>
+    </div>
+    <div v-if="isPortfolio" class="portfolio">포폴있음</div>
+    <div v-if="!isPortfolio" class="no-portfolio">
+      <div class="no-login-content">
+        <p class="nologin-text">
+          더 정확한 추천을 위해 <br />포트폴리오를 생성해주세요!
+        </p>
+        <button class="detail-button" @click="goToPortfolio">
+          포트폴리오 생성하기
+        </button>
+      </div>
+    </div>
   </div>
 
   <!-- 비로그인 상태일 때: 랜덤 이미지 & 문구 -->
@@ -48,9 +69,19 @@ import { useRouter } from 'vue-router';
 const router = useRouter();
 const authStore = useAuthStore();
 const isLoggedIn = computed(() => authStore.isLoggedIn);
+const isstats = ref(false);
+const isPortfolio = ref(false);
 
 const goToStatsPage = () => {
   router.push('/my-stats');
+};
+
+const goToPortfolio = () => {
+  router.push('/my-portfolio');
+};
+
+const goToTest = () => {
+  router.push('/quizstart');
 };
 
 const statsLeft = [
@@ -145,8 +176,8 @@ onMounted(() => {
 .detail-button {
   width: 11vw;
   height: 4vh;
-  background-color: var(--color-main-button);
-  border: none;
+  background-color: var(--color-white);
+  border: 0.2vh solid var(--color-light-gray);
   border-radius: 2vh;
   font-weight: var(--font-weight-extrabold);
   cursor: pointer;
@@ -154,9 +185,14 @@ onMounted(() => {
 }
 
 .detail-button:hover {
-  box-shadow: 0 0.5vh 0.5vw rgba(0, 0, 0, 0.3);
+  background-color: var(--color-main-button);
+  border: none;
+  color: var(--color-white);
+  box-shadow: 0 0.2vh 0.2vw rgba(0, 0, 0, 0.3);
   transform: translateY(-0.5vh);
 }
+
+/* 비로그인시 */
 
 .description {
   font-size: 2rem;
@@ -180,5 +216,49 @@ onMounted(() => {
 .animal-image.fade-in {
   opacity: 1;
   transform: scale(1);
+}
+
+/* 로그인시 */
+.show-stats-container-notlogin {
+  width: 70vw;
+  height: 35vh;
+  border: 0.2vh solid var(--color-light-gray);
+  background-color: var(--color-light-yellow);
+  box-shadow: 0 1vh 1vw rgba(50, 50, 50, 0.15);
+  border-radius: 2vh;
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  justify-content: center;
+  padding: 2vh;
+  overflow: hidden;
+  font-family: var(--font-wanted);
+  font-weight: var(--font-weight-extrabold);
+}
+
+.no-stats {
+  width: 50%;
+  height: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border-right: 0.2vh solid var(--color-light-gray);
+}
+
+.no-portfolio {
+  width: 50%;
+  height: 100%;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+.no-login-content {
+  text-align: center;
+}
+
+.nologin-text {
+  font-size: 1.5rem;
+  text-align: center;
+  color: var(--color-gray);
 }
 </style>

--- a/FinMate/src/components/main/ShowStatsContainer.vue
+++ b/FinMate/src/components/main/ShowStatsContainer.vue
@@ -46,7 +46,7 @@
         class="no-login-content portfolio-animated"
         :class="{ revealed: portfolioRevealed }"
       >
-        <p class="nologin-text">📊 나의 자산 현황</p>
+        <p class="nologin-text2">📊 나의 자산 현황</p>
         <div class="portfolio-grid">
           <p>💰 총 자산: {{ portfolioData.totalAssets.toLocaleString() }}원</p>
           <p>📈 주식: {{ portfolioData.stock.toLocaleString() }}원</p>
@@ -332,13 +332,19 @@ const handleMouseLeave = () => {
 }
 
 .nologin-text {
+  width: 15vw;
+  height: 12vh;
   font-size: 1.2rem;
   text-align: center;
+  display: flex;
+  align-items: center;
+  justify-content: center;
   color: var(--color-black);
   position: relative;
   background: var(--color-main-button);
   border-radius: 2vh;
   padding: 1vh;
+  font-weight: var(--font-weight-medium);
 }
 .nologin-text:after {
   content: '';

--- a/FinMate/src/components/main/ShowStatsContainer.vue
+++ b/FinMate/src/components/main/ShowStatsContainer.vue
@@ -22,6 +22,12 @@
     <button class="detail-button" @click="goToStatsPage">자세히 보기</button> -->
     <div v-if="isstats" class="stats"></div>
     <div v-if="!isstats" class="no-stats">
+      <div>
+        <img
+          class="animal-image-logo"
+          src="@/assets/images/animals/penguin.png"
+        />
+      </div>
       <div class="no-login-content">
         <p class="nologin-text">
           추천 아이템을 받으려면 <br />
@@ -57,6 +63,12 @@
       </div>
     </div>
     <div v-if="!isPortfolio" class="no-portfolio">
+      <div>
+        <img
+          class="animal-image-logo"
+          src="@/assets/images/animals/capybara.png"
+        />
+      </div>
       <div class="no-login-content">
         <p class="nologin-text">
           더 정확한 추천을 위해 <br />포트폴리오를 생성해주세요!
@@ -322,12 +334,35 @@ const handleMouseLeave = () => {
 .nologin-text {
   font-size: 1.2rem;
   text-align: center;
-  color: var(--color-gray);
+  color: var(--color-black);
+  position: relative;
+  background: var(--color-main-button);
+  border-radius: 2vh;
+  padding: 1vh;
 }
+.nologin-text:after {
+  content: '';
+  position: absolute;
+  left: 0;
+  width: 0;
+  height: 0;
+  border: 1em solid transparent;
+  border-right-color: var(--color-main-button);
+  border-left: 0;
+  border-bottom: 0;
+  margin-top: -0.5em;
+  margin-left: -0.8em;
+}
+
+.animal-image-logo {
+  width: 12vw;
+  transform: scaleX(-1);
+}
+
 .portfolio-grid {
   display: grid;
   grid-template-columns: repeat(2, auto);
-  gap: 0.3rem;
+  gap: 0.4rem 1rem;
   text-align: left;
   font-size: 1rem;
 }


### PR DESCRIPTION
## 🔗 반영 브랜치

(closed #88  ) feature/main-portfolio -> develop

## 📝 작업 내용
<img width="1409" height="402" alt="스크린샷 2025-08-01 오후 1 58 53" src="https://github.com/user-attachments/assets/224a6a1a-22a5-451a-8f79-f98e3a40d34a" />

스탯, 포트폴리오 없을 시


<img width="1396" height="376" alt="스크린샷 2025-08-01 오후 2 01 09" src="https://github.com/user-attachments/assets/a714acc7-c690-4521-9098-cc28b4d3d941" />

포트폴리오 있을 때(개인정보 때문에 처음엔 블러 처리)


<img width="1393" height="380" alt="스크린샷 2025-08-01 오후 2 01 16" src="https://github.com/user-attachments/assets/82757675-6744-429d-b269-495fe76d7ff5" />

마우스 갖다대면 블러가 서서히 사라짐


+

<img width="1389" height="370" alt="image" src="https://github.com/user-attachments/assets/4b91eb9f-1537-4c87-b1b6-0cf29ffe6ec2" />

폰트 굵기 및 말풍선 크기 수정했습니다!

## 💬 리뷰 요구사항

말풍선 옆 동물 사진은 원하시는 거 있으면 언제든지 바꿀 수 있습니다! 참고해주세요!
