### PR TITLE
♻️ 재무 포트폴리오 CSS 조절 및 구분선 추가

### DIFF
--- a/FinMate/src/components/info/portfolio/PortfolioAnalyzeChart.vue
+++ b/FinMate/src/components/info/portfolio/PortfolioAnalyzeChart.vue
@@ -97,7 +97,7 @@ function statusClass(diff) {
     <canvas ref="chartCanvasRef" class="bar-chart"></canvas>
     <div class="button-container">
       <button @click="showExplanation = !showExplanation" class="info-button">
-        {{ showExplanation ? '닫기' : '자세히 보기' }}
+        {{ showExplanation ? '접기' : '자세히 보기' }}
       </button>
     </div>
   </div>

--- a/FinMate/src/components/info/portfolio/PortfolioCompareModal.vue
+++ b/FinMate/src/components/info/portfolio/PortfolioCompareModal.vue
@@ -108,6 +108,7 @@ function renderCurrentChart(data) {
             <h3>현재 재무 포트폴리오</h3>
             <canvas ref="chartCanvasRefNow" class="now-chart"></canvas>
           </div>
+          <div class="vertical-line"></div>
           <div class="chart-box">
             <h3>과거 재무 포트폴리오</h3>
             <PortfolioPastChart
@@ -204,6 +205,13 @@ function renderCurrentChart(data) {
   max-width: 550px;
   margin-left: 5rem;
   margin-right: 5rem;
+}
+
+.vertical-line {
+  margin-top: 5rem;
+  width: 4px;
+  height: 570px;
+  background-color: var(--color-dark-gray);
 }
 
 .now-chart {

--- a/FinMate/src/components/info/portfolio/PortfolioData.vue
+++ b/FinMate/src/components/info/portfolio/PortfolioData.vue
@@ -253,7 +253,7 @@ canvas {
 .asset-cards-row {
   display: flex;
   flex-direction: row;
-  gap: 1.5rem;
+  gap: 1.3rem;
   justify-content: center;
   margin-top: 1rem;
   flex-wrap: wrap;
@@ -274,7 +274,7 @@ canvas {
 
 .asset-row {
   margin-bottom: 0.6rem;
-  padding: 0.5rem;
+  padding: 0.4rem;
 }
 
 .asset-title {
@@ -290,7 +290,7 @@ canvas {
   background-color: var(--color-white);
   border-radius: 12px;
   text-align: center;
-  width: 14rem;
+  width: 12.5rem;
   font-size: 1.1rem;
   font-weight: var(--font-weight-bold);
   padding-bottom: 0.4rem;

--- a/FinMate/src/views/info/MyPortfolioView.vue
+++ b/FinMate/src/views/info/MyPortfolioView.vue
@@ -66,16 +66,17 @@ onMounted(fetchPortfolio);
 .myportfolio-container {
   display: flex;
   gap: 2rem;
-  padding: 2.55rem 4.9rem;
+  padding: 2rem 5.35rem;
   width: 100vw;
   height: 100vh;
 }
 .right-panel {
+  flex: 1;
   padding: 1rem 2rem;
   border: 3px solid var(--color-primary-bluegray);
   border-radius: 4px;
-  max-height: 80vh;
-  max-width: 80vw;
+  max-height: 90vh;
+  max-width: 90vw;
   overflow-y: auto;
 }
 </style>


### PR DESCRIPTION
## 🔗 반영 브랜치

(#120 ) refactor/portfolio -> develop

## 📝 작업 내용
**1. 현재 재무 포트폴리오와 과거 재무 포트폴리오 사이를 나누는 구분선 추가**

**2. 재무 포트폴리오 분석 모달에서 맥락에 맞게 접기 버튼으로 변경**

**3. 재무 포트폴리오 메인 페이지에서 assets-card 목록이 일정 화면 크기 이하에서만 줄 바꿈이 되도록 수정**

**4. 마이페이지에서 Reviews, Products, Stat 페이지와 동일하게 패널 위치 조정**

## 💬 리뷰 요구사항(선택 사항)

