### PR TITLE
♻️메인 페이지 포트폴리오 미니 차트 추가 및 기타 수정

### DIFF
--- a/FinMate/src/components/info/portfolio/PortfolioModal.vue
+++ b/FinMate/src/components/info/portfolio/PortfolioModal.vue
@@ -1,6 +1,8 @@
+``
 <script setup>
 import { ref, onMounted } from 'vue';
 import { createPortfolio, updatePortfolio } from '@/api/portfolio/portfolio.js';
+import { Info } from 'lucide-vue-next';
 
 const emit = defineEmits(['close', 'save']);
 const error = ref(false);
@@ -57,6 +59,7 @@ async function onSubmit() {
   try {
     if (props.mode === 'edit') {
       await updatePortfolio(fullData);
+      console.log(fullData);
     } else {
       await createPortfolio(fullData);
     }
@@ -97,6 +100,10 @@ function onCancel() {
       <div class="btn-group">
         <button class="btn-cancel" @click="onCancel">취소</button>
         <button class="btn-submit" @click="onSubmit">저장</button>
+      </div>
+      <div>
+        <info size="3%" class="info-img" /> 기타자산은 예금, 적금, 채권, 펀드,
+        주식을 제외한 금융자산을 의미합니다.
       </div>
     </div>
   </div>
@@ -214,5 +221,9 @@ input {
 .btn-cancel:hover {
   color: var(--color-white);
   background-color: var(--color-red);
+}
+
+.info-img {
+  color: var(--color-dark-gray);
 }
 </style>

--- a/FinMate/src/components/main/MainProductCard.vue
+++ b/FinMate/src/components/main/MainProductCard.vue
@@ -150,6 +150,10 @@ const getBankCodeFromName = (bankName) => {
   return bankName.charAt(0).toLowerCase();
 };
 
+const getBankInitial = (bankName) => {
+  return bankName.charAt(0);
+};
+
 const handleImageError = (event) => {
   const bankIcon = event.target.parentElement;
   event.target.style.display = 'none';

--- a/FinMate/src/components/main/ShowStatsContainer.vue
+++ b/FinMate/src/components/main/ShowStatsContainer.vue
@@ -31,7 +31,7 @@
           <span class="stat-label">
             <div class="tooltip-wrapper">
               <span class="icon"><Coins /></span>
-              <span class="tooltip-text">금융 성향 점수</span>
+              <span class="tooltip-text">재정 체력</span>
             </div></span
           >
           <div class="stat-bar-outer">

--- a/FinMate/src/components/main/ShowStatsContainer.vue
+++ b/FinMate/src/components/main/ShowStatsContainer.vue
@@ -108,15 +108,36 @@
         class="no-login-content portfolio-animated"
         :class="{ revealed: portfolioRevealed }"
       >
-        <p class="nologin-text2">📊 나의 자산 현황</p>
-        <div class="portfolio-grid">
-          <p>💰 총 자산: {{ portfolioData.totalAssets.toLocaleString() }}원</p>
-          <p>📈 주식: {{ portfolioData.stock.toLocaleString() }}원</p>
-          <p>📉 채권: {{ portfolioData.bond.toLocaleString() }}원</p>
-          <p>🏦 예금: {{ portfolioData.deposit.toLocaleString() }}원</p>
-          <p>💼 펀드: {{ portfolioData.fund.toLocaleString() }}원</p>
-          <p>💳 현금: {{ portfolioData.cash.toLocaleString() }}원</p>
-          <p>📦 기타: {{ portfolioData.other.toLocaleString() }}원</p>
+        <p class="nologin-text2">
+          <UserRoundCheck class="UserRoundCheck" /><span class="highlight-text"
+            >나의 자산 현황</span
+          >
+          : {{ portfolioData.totalAssets.toLocaleString() }}원
+        </p>
+        <div class="portfolio-info">
+          <div class="portfolio-chart">
+            <canvas ref="chartCanvasRef"></canvas>
+          </div>
+          <div class="portfolio-grid">
+            <div class="portfolio-col">
+              <p>주식: {{ portfolioData.stock.toLocaleString() }}원</p>
+              <p>
+                예적금:
+                {{
+                  (
+                    portfolioData.deposit + portfolioData.savings
+                  ).toLocaleString()
+                }}원
+              </p>
+              <p>현금: {{ portfolioData.cash.toLocaleString() }}원</p>
+            </div>
+
+            <div class="portfolio-col">
+              <p>채권: {{ portfolioData.bond.toLocaleString() }}원</p>
+              <p>펀드: {{ portfolioData.fund.toLocaleString() }}원</p>
+              <p>기타: {{ portfolioData.other.toLocaleString() }}원</p>
+            </div>
+          </div>
         </div>
         <button class="detail-button" @click="goToPortfolio">
           자세히 보기
@@ -158,11 +179,22 @@
 </template>
 
 <script setup>
-import { ref, onMounted, computed } from 'vue';
+import { ref, onMounted, computed, nextTick, watch } from 'vue';
 import { useAuthStore } from '@/stores/auth/auth';
 import { useRouter } from 'vue-router';
 import { getPortfolio, getMemberStat } from '@/api/main/main.js';
-import { Swords, Coins, Gauge, Brain, Sparkle } from 'lucide-vue-next';
+import {
+  Swords,
+  Coins,
+  Gauge,
+  Brain,
+  Sparkle,
+  UserRoundCheck,
+} from 'lucide-vue-next';
+import { Chart } from 'chart.js/auto';
+
+const chartCanvasRef = ref(null);
+let chartInstance = null;
 
 const router = useRouter();
 const authStore = useAuthStore();
@@ -234,6 +266,11 @@ onMounted(async () => {
       const portfolio = await getPortfolio();
       isPortfolio.value = !!portfolio && Object.keys(portfolio).length > 0;
       portfolioData.value = portfolio;
+
+      if (isPortfolio.value) {
+        await nextTick();
+        renderPortfolioChart();
+      }
     } catch (e) {
       if (e.response?.status === 404) isPortfolio.value = false;
     } finally {
@@ -251,6 +288,61 @@ onMounted(async () => {
     }
   }
 });
+
+watch(isPortfolio, async (v) => {
+  if (v) {
+    await nextTick();
+    requestAnimationFrame(() => {
+      renderPortfolioChart();
+    });
+  }
+});
+
+function renderPortfolioChart() {
+  const canvas = chartCanvasRef.value;
+  if (!canvas) return;
+  const ctx = canvas.getContext('2d');
+
+  if (chartInstance) {
+    chartInstance.destroy();
+    chartInstance = null;
+  }
+
+  chartInstance.value = new Chart(ctx, {
+    type: 'pie',
+    data: {
+      labels: ['현금', '예금', '적금', '채권', '펀드', '주식', '기타'],
+      datasets: [
+        {
+          data: [
+            portfolioData.value.cash,
+            portfolioData.value.deposit,
+            portfolioData.value.savings,
+            portfolioData.value.bond,
+            portfolioData.value.fund,
+            portfolioData.value.stock,
+            portfolioData.value.other,
+          ],
+          backgroundColor: [
+            '#9ECAD6',
+            '#748DAE',
+            '#F5CBCB',
+            '#FFEAEA',
+            '#A3DC9A',
+            '#DEE791',
+            '#DCD0A8',
+          ],
+          hoverOffset: 7,
+        },
+      ],
+    },
+    options: {
+      plugins: {
+        legend: { display: false },
+      },
+    },
+  });
+}
 </script>
 
 <style scoped>
@@ -340,6 +432,7 @@ onMounted(async () => {
   font-weight: var(--font-weight-extrabold);
   cursor: pointer;
   transition: all 0.1s ease;
+  margin: 0 auto;
 }
 
 .detail-button:hover {
@@ -415,7 +508,6 @@ onMounted(async () => {
   height: 100%;
   display: flex;
   align-items: center;
-  justify-content: center;
   cursor: pointer;
 }
 
@@ -465,11 +557,25 @@ onMounted(async () => {
 }
 
 .portfolio-grid {
+  margin-left: auto;
+  margin-right: 2rem;
   display: grid;
-  grid-template-columns: repeat(2, auto);
-  gap: 0.4rem 1rem;
+  grid-template-columns: auto auto;
+  column-gap: 2rem;
+  align-items: start;
   text-align: left;
   font-size: 1rem;
+}
+
+.portfolio-col {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.portfolio-chart {
+  max-width: 210px;
+  margin-left: 3rem;
 }
 
 .portfolio-animated {
@@ -477,6 +583,26 @@ onMounted(async () => {
   filter: blur(4px);
   transition: all 0.8s ease;
   pointer-events: none;
+  width: 100%;
+}
+
+.nologin-text2 {
+  display: flex;
+  justify-content: center;
+  font-size: 1.2rem;
+}
+
+.highlight-text {
+  background: linear-gradient(transparent 55%, rgba(255, 255, 0, 0.6) 55%);
+}
+
+.UserRoundCheck {
+  margin-right: 0.5rem;
+}
+
+.portfolio-info {
+  display: flex;
+  align-items: center;
 }
 
 .portfolio-animated.revealed {


### PR DESCRIPTION
## 🔗 반영 브랜치

(#133 ) refactor/main-page -> develop

## 📝 작업 내용

### **1. 메인 페이지에 재무 포트폴리오 미니 차트 구현**
<img width="1897" height="925" alt="스크린샷 2025-08-09 113106" src="https://github.com/user-attachments/assets/b87e7adb-83a8-4941-b857-e48cee9a7a2e" />

-- 차트 추가함에 따라 portfolio 요소들 위치와 크기를 조정하였습니다.


### **2. 재무 포트폴리오 작성, 수정 모달에 기타자산과 관련한 안내사항 추가
<img width="1911" height="931" alt="스크린샷 2025-08-09 113118" src="https://github.com/user-attachments/assets/da478866-4703-4e39-b490-6b34ef7aa90e" />

-- 사용자의 입장에서 기타자산에 대한 정의가 모호할 수 있어 안내사항을 추가하였습니다.


### **3. 메인페이지 금융 성향 점수 -> 재정 체력으로 문구 수정
<img width="715" height="396" alt="image" src="https://github.com/user-attachments/assets/c339f0c2-2bca-427f-b8b4-cb3cdf30b6fb" />


### **4. Product-card에서 이미지 헨들러 오류 수정

## 💬 리뷰 요구사항(선택 사항)

