### PR TITLE
✨보유 상품 마이데이터 연동

### DIFF
--- a/FinMate/src/api/info/userReviewAPI.js
+++ b/FinMate/src/api/info/userReviewAPI.js
@@ -1,11 +1,11 @@
-import axios from "axios";
+import axios from 'axios';
 
 const BASE_API_URL = import.meta.env.VITE_BASE_API_URL;
 
 export const getMyReviews = async () => {
   try {
-    const token = localStorage.getItem("token");
-    const response = await axios.get(`${BASE_API_URL}/api/member/review`, {
+    const token = localStorage.getItem('token');
+    const response = await axios.get(`${BASE_API_URL}/api/my-page/review`, {
       headers: {
         Authorization: `Bearer ${token}`,
       },
@@ -13,13 +13,31 @@ export const getMyReviews = async () => {
     });
     return response.data;
   } catch (error) {
-    console.error("리뷰 조회 실패:", error);
+    console.error('리뷰 조회 실패:', error);
+    throw error;
+  }
+};
+
+export const getMyProducts = async () => {
+  try {
+    const token = localStorage.getItem('token');
+    const response = await axios.get(
+      `${BASE_API_URL}/api/my-page/my-products`,
+      {
+        headers: {
+          Authorization: `Bearer ${token}`,
+        },
+      }
+    );
+    return response.data;
+  } catch (error) {
+    console.error('보유한 상품 조회 실패:', error);
     throw error;
   }
 };
 
 export const deleteMyReview = async (productId) => {
-  const token = localStorage.getItem("token");
+  const token = localStorage.getItem('token');
   const response = await axios.delete(
     `${BASE_API_URL}/api/product/${productId}/review`,
     {

--- a/FinMate/src/components/info/UserProductCard.vue
+++ b/FinMate/src/components/info/UserProductCard.vue
@@ -5,22 +5,52 @@
       <div class="type-wrapper">
         <span class="type">{{ type }}</span>
       </div>
-      <span v-if="showTag" class="tag" :class="tagClass">
-        {{ isExpired ? "만기완료" : "만기전" }}
-      </span>
     </div>
-
     <ul>
-      <li v-for="(label, key) in infoList" :key="key">
-        <span class="label">{{ label }}</span>
-        <span class="value">{{ product[key] }}</span>
+      <li>
+        <span class="label">상품명</span
+        ><span class="value">{{ product.name }}</span>
+      </li>
+      <li>
+        <span class="label">상품유형</span
+        ><span class="value">{{ product.type }}</span>
+      </li>
+      <li>
+        <span class="label">금융기관</span
+        ><span class="value">{{ product.bank }}</span>
+      </li>
+      <li>
+        <span class="label">가입금액</span
+        ><span class="value">{{ product.amount }}</span>
+      </li>
+      <li>
+        <span class="label">기대 수익률</span
+        ><span class="value">{{ product.return }}%</span>
+      </li>
+
+      <li v-if="product.start">
+        <span class="label">가입일</span
+        ><span class="value">{{ product.start }}</span>
+      </li>
+      <li v-if="product.end">
+        <span class="label">만기일</span
+        ><span class="value">{{ product.end }}</span>
+      </li>
+
+      <li v-if="product.fundType">
+        <span class="label">펀드유형</span
+        ><span class="value">{{ product.fundType }}</span>
+      </li>
+      <li v-if="product.riskLevel">
+        <span class="label">위험도</span
+        ><span class="value">{{ riskLevelText }}</span>
       </li>
     </ul>
   </div>
 </template>
 
 <script setup>
-import { computed } from "vue";
+import { computed } from 'vue';
 
 const props = defineProps({
   icon: String,
@@ -28,28 +58,17 @@ const props = defineProps({
   product: Object,
 });
 
-const infoList = {
-  name: "상품명",
-  bank: "금융기관명",
-  amount: "가입금액",
-  rate: "이자율/수익률",
-  start: "가입일",
-  end: "만기일",
-};
-
-const showTag = computed(() => props.type === "예금" || props.type === "적금");
-
-const isExpired = computed(() => {
-  if (!props.product.end || props.product.end === "제한 없음") return false;
-  const today = new Date();
-  const endDate = new Date(props.product.end);
-  return endDate < today;
-});
-
-const tagClass = computed(() => {
-  if (props.type === "예금") return "tag-deposit";
-  if (props.type === "적금") return "tag-saving";
-  return "";
+const riskLevelText = computed(() => {
+  const level = props.product.riskLevel;
+  const map = {
+    2: '매우 낮음',
+    3: '낮음',
+    4: '중간',
+    5: '다소 높음',
+    6: '높음',
+    7: '매우 높음',
+  };
+  return map[level];
 });
 </script>
 

--- a/FinMate/src/views/info/MyProducts.vue
+++ b/FinMate/src/views/info/MyProducts.vue
@@ -14,7 +14,7 @@
               />
             </div>
             <p class="subtitle-left">
-              총 <span class="highlight">{{ userProductList.length }}</span
+              총 <span class="highlight">{{ filteredProducts.length }}</span
               >개의 상품을 보유 중이에요!
             </p>
 
@@ -36,19 +36,81 @@
 </template>
 
 <script setup>
-import { ref, computed } from 'vue';
-
+import { ref, computed, onMounted } from 'vue';
 import Sidebar from '@/components/info/Sidebar.vue';
 import TopNavigationBar from '@/components/allshared/TopNavigationBar.vue';
 import RightPanel from '@/components/info/RightPanel.vue';
 import CategoryFilterBar from '@/components/info/CategoryFilterBar.vue';
 import UserProductCard from '@/components/info/UserProductCard.vue';
+import FooterComponent from '@/components/allshared/FooterComponent.vue';
 import depositIcon from '@/assets/images/products/deposit.png';
 import savingIcon from '@/assets/images/products/saving.png';
 import fundIcon from '@/assets/images/products/fund.png';
-import FooterComponent from '../../components/allshared/FooterComponent.vue';
+
+import { getMyProducts } from '@/api/info/userReviewAPI.js';
 
 const selectedCategory = ref('all');
+const products = ref([]);
+const userProductList = ref([]);
+
+function formatDate(ms) {
+  if (!ms) return '-';
+  const d = new Date(ms);
+  return isNaN(d.getTime()) ? '-' : d.toISOString().split('T')[0];
+}
+function formatAmount(amt) {
+  return amt ? `${amt.toLocaleString()}원` : '-';
+}
+function getTypeLabel(type) {
+  return type === 'DEPOSIT'
+    ? '예금'
+    : type === 'SAVINGS'
+    ? '적금'
+    : type === 'FUND'
+    ? '펀드'
+    : '기타';
+}
+function getIcon(type) {
+  if (type === 'DEPOSIT') return depositIcon;
+  if (type === 'SAVINGS') return savingIcon;
+  if (type === 'FUND') return fundIcon;
+  return depositIcon;
+}
+function changeProductCard(apiData) {
+  return apiData.map((item) => {
+    const type = getTypeLabel(item.prod_type);
+    const baseProduct = {
+      name: item.prod_name,
+      type,
+      bank: item.bank_name,
+      amount: formatAmount(item.balance_amt),
+      return: item.expected_return ?? '-',
+    };
+    if (item.prod_type === 'DEPOSIT' || item.prod_type === 'SAVINGS') {
+      baseProduct.start = formatDate(item.start_date);
+      baseProduct.end = formatDate(item.end_date);
+    }
+    if (item.prod_type === 'FUND') {
+      baseProduct.fundType = item.fund_type ?? '-';
+      baseProduct.riskLevel = item.risk_level ?? '-';
+    }
+    return {
+      type,
+      icon: getIcon(item.prod_type),
+      product: baseProduct,
+    };
+  });
+}
+
+onMounted(async () => {
+  try {
+    const data = await getMyProducts();
+    products.value = data.registered_list;
+    userProductList.value = changeProductCard(products.value);
+  } catch (e) {
+    console.error('상품 조회 실패', e);
+  }
+});
 
 const categories = [
   { label: '전체', value: 'all' },
@@ -57,73 +119,11 @@ const categories = [
   { label: '펀드', value: '펀드' },
 ];
 
-// TODO: api 연동(API 연동 전용 mock 데이터)
-const userProductList = [
-  {
-    type: '예금',
-    icon: depositIcon,
-    product: {
-      name: '스마트정기예금',
-      bank: 'KB 국민은행',
-      amount: '1,000,000원',
-      rate: '연 2.3%',
-      start: '2025-05-01',
-      end: '2026-05-01',
-    },
-  },
-  {
-    type: '적금',
-    icon: savingIcon,
-    product: {
-      name: '자유적립적금',
-      bank: '우리은행',
-      amount: '500,000원',
-      rate: '연 2.8%',
-      start: '2025-04-10',
-      end: '2026-04-10',
-    },
-  },
-  {
-    type: '펀드',
-    icon: fundIcon,
-    product: {
-      name: '글로벌테크펀드',
-      bank: 'NH 투자증권',
-      amount: '2,000,000원',
-      rate: '변동수익 (최근 +5.2%)',
-      start: '2025-03-20',
-      end: '제한 없음',
-    },
-  },
-  {
-    type: '예금',
-    icon: depositIcon,
-    product: {
-      name: '비대면전용예금',
-      bank: '카카오뱅크',
-      amount: '2,000,000원',
-      rate: '연 2.45%',
-      start: '2025-07-01',
-      end: '2026-07-01',
-    },
-  },
-  {
-    type: '적금',
-    icon: savingIcon,
-    product: {
-      name: '매일적금',
-      bank: 'IBK 기업은행',
-      amount: '300,000원',
-      rate: '연 3.0%',
-      start: '2025-06-01',
-      end: '2026-06-01',
-    },
-  },
-];
-
 const filteredProducts = computed(() => {
-  if (selectedCategory.value === 'all') return userProductList;
-  return userProductList.filter((item) => item.type === selectedCategory.value);
+  if (selectedCategory.value === 'all') return userProductList.value;
+  return userProductList.value.filter(
+    (item) => item.type === selectedCategory.value
+  );
 });
 </script>
 

--- a/FinMate/src/views/info/MyProducts.vue
+++ b/FinMate/src/views/info/MyProducts.vue
@@ -103,13 +103,9 @@ function changeProductCard(apiData) {
 }
 
 onMounted(async () => {
-  try {
-    const data = await getMyProducts();
-    products.value = data.registered_list;
-    userProductList.value = changeProductCard(products.value);
-  } catch (e) {
-    console.error('상품 조회 실패', e);
-  }
+  const data = await getMyProducts();
+  products.value = data.registered_list;
+  userProductList.value = changeProductCard(products.value);
 });
 
 const categories = [


### PR DESCRIPTION
## 🔗 반영 브랜치

(#155 ) feature/mypage-products -> develop

## 📝 작업
### **1. 마이페이지 보유 상품에서 기존의 mockup 데이터 대신 마이 데이터 상품 연동**
<img width="1906" height="936" alt="스크린샷 2025-08-12 104545" src="https://github.com/user-attachments/assets/671ef2b0-7f58-42f9-9ee9-6f362141d10d" />
-- 금융 상품 공통 속성으로 상품명, 상품 유형, 금융 기관, 가입 금액, 기대 수익률이 포함됩니다.


-- 예적금 상품 속성으로 가입일, 만기일이 들어가며 펀드 상품 속성으로는 펀드 유형과 위험도를 넣었습니다.

### **2. 마이페이지 리뷰 API 수정 및 마이 데이터 API 추가


## 💬 리뷰 요구사항(선택 사항)
상품 속성과 관련하여 의견이 있다면 말씀해 주세요!!
