### PR TITLE
💄 회원가입 설문 페이지 css 수정 

### DIFF
--- a/FinMate/src/components/auth/SurveyComponent.vue
+++ b/FinMate/src/components/auth/SurveyComponent.vue
@@ -118,23 +118,21 @@ onMounted(() => {
             </label>
           </li>
         </ul>
+        <!-- 이전/다음 버튼 -->
+        <div class="survey-navigation">
+          <button @click="prevQuestion" :disabled="currentIndex === 0">
+            ◀ 이전
+          </button>
+          <span>{{ currentIndex + 1 }} / {{ surveyData.length }}</span>
+          <button
+            @click="nextQuestion"
+            :disabled="currentIndex === surveyData.length - 1"
+          >
+            다음 ▶
+          </button>
+        </div>
       </div>
     </transition>
-
-    <!-- 이전/다음 버튼 -->
-    <div class="survey-navigation">
-      <button @click="prevQuestion" :disabled="currentIndex === 0">
-        ◀ 이전
-      </button>
-      <span>{{ currentIndex + 1 }} / {{ surveyData.length }}</span>
-      <button
-        @click="nextQuestion"
-        :disabled="currentIndex === surveyData.length - 1"
-      >
-        다음 ▶
-      </button>
-    </div>
-
     <!-- 제출 버튼 -->
     <div class="submit-container">
       <button
@@ -199,6 +197,9 @@ onMounted(() => {
   font-weight: bold;
   margin-bottom: 1rem;
 }
+.survey-card {
+  background-color: rgba(255, 255, 255, 0.8);
+}
 
 /* 선택지 */
 .survey-options li {
@@ -244,7 +245,10 @@ onMounted(() => {
   width: 100%;
   justify-content: space-between;
   align-items: center;
-  padding: 2vh;
+  padding: 5vh;
+  padding-top: 0vh;
+  padding-bottom: 0vh;
+  margin: 0;
 }
 .survey-navigation button {
   background-color: var(--color-primary-green);

--- a/FinMate/src/styles/reset.css
+++ b/FinMate/src/styles/reset.css
@@ -57,6 +57,7 @@ button {
 
 /* 설문지 카드 */
 .survey-card {
+  background-color: rgba(255, 255, 255, 0.9);
   border-radius: var(--card-radius);
   box-shadow: var(--card-shadow);
   width: 70vw;
@@ -67,4 +68,8 @@ button {
   display: flex;
   flex-direction: column;
   border: 0.2vh solid var(--color-light-gray);
+  margin-top: 0;
+  margin-bottom: 0vh;
+  padding: 0;
+  height: 50vh;
 }

--- a/FinMate/src/views/auth/SignUpSurvey.vue
+++ b/FinMate/src/views/auth/SignUpSurvey.vue
@@ -38,7 +38,7 @@ import SurveyComponent from '@/components/auth/SurveyComponent.vue';
   background-size: cover;
   background-position: center;
   background-repeat: no-repeat;
-  opacity: 0.3;
+  /* opacity: 0.3; */
   z-index: -1;
 }
 


### PR DESCRIPTION
## 🔗 반영 브랜치

(#200 ) feature/SignupSurvey-css -> develop

## 📝 작업 내용

회원 가입 설문 페이지 css 수정
1. 버튼 위치 보더 내부로 이동
2. 보더 투명도 조절

<img width="1907" height="903" alt="스크린샷 2025-08-18 025120" src="https://github.com/user-attachments/assets/0b71f758-82ea-4206-a460-8b667e14c40a" />


## 💬 리뷰 요구사항(선택 사항)
보더 투명도 이 정도면 괜찮을까요~


리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요

> 예시) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
